### PR TITLE
feat(sett): implement custom risk percentage

### DIFF
--- a/src/features/settings/components/StrategyForm.tsx
+++ b/src/features/settings/components/StrategyForm.tsx
@@ -7,15 +7,23 @@ import {
 } from "@/components/ui/select";
 import { StrategyProps } from "../settingsTypes";
 import { Slider } from "@/components/ui/slider";
+import { BaseSyntheticEvent } from "react";
 
 const StrategyForm = ({
   setStrategy,
   currentStrategy,
   handleSubmit,
+  strategy,
 }: StrategyProps) => {
   const handleStrategyChange = (value: string) => {
     setStrategy((currBotSettings) => {
       return { ...currBotSettings, strategy: value };
+    });
+    console.log(strategy);
+  };
+  const handleRiskChange = (event: BaseSyntheticEvent) => {
+    setStrategy((currBotSettings) => {
+      return { ...currBotSettings, risk: event.target.value };
     });
   };
 
@@ -37,8 +45,14 @@ const StrategyForm = ({
         </Select>
       </div>
       <div className="flex flex-col gap-4">
-        Risk %: 10{" "}
-        <Slider defaultValue={[50]} max={100} step={1} className="" />
+        Risk %: {strategy.risk}
+        <Slider
+          defaultValue={[currentStrategy.risk]}
+          max={100}
+          step={1}
+          className=""
+          onChange={handleRiskChange}
+        />
       </div>
     </form>
   );

--- a/src/features/settings/components/StrategyManagement.tsx
+++ b/src/features/settings/components/StrategyManagement.tsx
@@ -25,10 +25,12 @@ const StrategyManagement = () => {
   const [currentStrategy, setCurrentStrategy] = useState<BotSettings>({
     strategy: "",
     bot_on: false,
+    risk: 1,
   });
   const [strategy, setStrategy] = useState<BotSettings>({
     strategy: "",
     bot_on: false,
+    risk: 1,
   });
 
   useEffect(() => {
@@ -38,6 +40,7 @@ const StrategyManagement = () => {
         const strategySettings: BotSettings = {
           strategy: settingsData?.data.userSettings.strategy,
           bot_on: settingsData?.data.userSettings.bot_on,
+          risk: settingsData?.data.userSettings.risk,
         };
         setCurrentStrategy(strategySettings);
         setStrategy((currStrategy: BotSettings) => {

--- a/src/features/settings/settingsService.ts
+++ b/src/features/settings/settingsService.ts
@@ -11,9 +11,9 @@ export const postApiKeys = async (apiKeys: ApiKeys) => {
     };
     const path = `/api-keys/${apiKeys.username}`;
     const response = await comfy.post(path, request);
-    return response
+    return response;
   } catch (error: any) {
-    throw error
+    throw error;
   }
 };
 
@@ -31,10 +31,11 @@ export const postUserSettings = async (
   settings: BotSettings,
   username: string | undefined
 ) => {
-  const { strategy, bot_on } = settings;
+  const { strategy, bot_on, risk } = settings;
   const request = {
     strategy,
     bot_on,
+    risk,
   };
   try {
     const path = `/user-settings/${username}`;
@@ -49,10 +50,11 @@ export const patchUserSettings = async (
   settings: BotSettings,
   username: string | undefined
 ) => {
-  const { strategy, bot_on } = settings;
+  const { strategy, bot_on, risk } = settings;
   const request = {
     strategy,
     bot_on,
+    risk,
   };
   try {
     const path = `/user-settings/${username}`;

--- a/src/features/settings/settingsTypes.ts
+++ b/src/features/settings/settingsTypes.ts
@@ -10,6 +10,7 @@ export type ApiKeys = {
 export type BotSettings = {
   strategy: string;
   bot_on: boolean;
+  risk: number;
 };
 
 export type StrategyProps = {

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,4 +1,3 @@
-import { Separator } from "@/components/ui/separator";
 import Features from "@/features/landing/components/Features";
 import Hero from "@/features/landing/components/Hero";
 


### PR DESCRIPTION
Creates the logic to allow users to set their custom risk per trade via  percentage of their account balance

refactors component states to keep track of selected risk

refactors service function to get, post and patch risk

ensures changes are reflected in the database